### PR TITLE
feat: add DuraGraph Studio to local-dev docker-compose

### DIFF
--- a/docker-compose/local-dev/README.md
+++ b/docker-compose/local-dev/README.md
@@ -7,6 +7,7 @@ Complete local development environment with DuraGraph and all dependencies.
 | Service | Port | Description |
 |---------|------|-------------|
 | DuraGraph API | 8081 | Control plane REST API |
+| DuraGraph Studio | 3000 | Interactive UI for agent interaction |
 | PostgreSQL | 5432 | Event store and projections |
 | NATS JetStream | 4222 | Message broker |
 | NATS Monitoring | 8222 | NATS HTTP monitoring |
@@ -44,6 +45,7 @@ docker compose --profile with-redis up -d
 
 ## Accessing Services
 
+- **DuraGraph Studio:** http://localhost:3000 (Interactive UI)
 - **DuraGraph API:** http://localhost:8081
 - **Health Check:** http://localhost:8081/health
 - **Metrics:** http://localhost:9090/metrics

--- a/docker-compose/local-dev/docker-compose.yml
+++ b/docker-compose/local-dev/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   # DuraGraph Control Plane
   duragraph:
-    image: ghcr.io/duragraph/duragraph:latest
+    image: duragraph/duragraph:latest
     ports:
       - "8081:8081"
       - "9090:9090"  # Metrics
@@ -55,6 +55,17 @@ services:
     command: ["--jetstream", "--http_port", "8222"]
     volumes:
       - nats_data:/data
+
+  # DuraGraph Studio (Interactive UI)
+  studio:
+    image: duragraph/studio:latest
+    ports:
+      - "3000:80"
+    environment:
+      - VITE_DURAGRAPH_API_URL=http://duragraph:8081
+    depends_on:
+      duragraph:
+        condition: service_healthy
 
   # Redis (optional, for caching)
   redis:


### PR DESCRIPTION
## Summary

Adds DuraGraph Studio to the local development docker-compose stack.

## Changes

- Add `studio` service using `duragraph/studio:latest` image
- Update README with Studio service documentation
- Use Docker Hub registry (`duragraph/*`) for all images

## Services After This PR

| Service | Port | Description |
|---------|------|-------------|
| DuraGraph API | 8081 | Control plane REST API |
| DuraGraph Studio | 3000 | Interactive UI for agent interaction |
| PostgreSQL | 5432 | Event store and projections |
| NATS JetStream | 4222 | Message broker |

## Usage

```bash
docker compose up -d
open http://localhost:3000
```

## Related

- https://github.com/Duragraph/duragraph-studio